### PR TITLE
Adapt charts for light mode

### DIFF
--- a/app/components/AttendanceTrendChart.tsx
+++ b/app/components/AttendanceTrendChart.tsx
@@ -51,7 +51,7 @@ const AttendanceTrendChart: FC<Props> = ({ data = attendanceTimeline, height = 4
       xAxis: s.start,
       yAxis: 0,
       itemStyle: {
-        color: index % 2 === 0 ? "rgba(107, 114, 128, 0.1)" : "rgba(107, 114, 128, 0.15)",
+        color: index % 2 === 0 ? "rgba(203, 213, 225, 0.15)" : "rgba(203, 213, 225, 0.25)",
       },
     },
     {
@@ -60,7 +60,7 @@ const AttendanceTrendChart: FC<Props> = ({ data = attendanceTimeline, height = 4
       label: {
         show: true,
         position: "insideTop",
-        color: "#9CA3AF",
+        color: "#4B5563",
         padding: 10,
         fontSize: 12,
         formatter: `${s.section}: ${s.topic}`,
@@ -112,7 +112,7 @@ const AttendanceTrendChart: FC<Props> = ({ data = attendanceTimeline, height = 4
       text: "Attendance Trend, Exits & Meeting Sections",
       left: "center",
       top: 5,
-      textStyle: { color: "#E5E7EB", fontSize: 16, fontWeight: "600" },
+      textStyle: { color: "#374151", fontSize: 16, fontWeight: "600" },
     },
     tooltip: {
       trigger: "axis",
@@ -132,8 +132,8 @@ const AttendanceTrendChart: FC<Props> = ({ data = attendanceTimeline, height = 4
       name: "Time (minutes)",
       nameLocation: "middle",
       nameGap: 30,
-      axisLabel: { color: "#9CA3AF" },
-      axisLine: { lineStyle: { color: "#6B7280" } },
+      axisLabel: { color: "#4B5563" },
+      axisLine: { lineStyle: { color: "#9CA3AF" } },
       interval: 20,
     },
     yAxis: {
@@ -143,8 +143,8 @@ const AttendanceTrendChart: FC<Props> = ({ data = attendanceTimeline, height = 4
       name: "Participants",
       nameLocation: "middle",
       nameGap: 35,
-      axisLabel: { color: "#9CA3AF" },
-      splitLine: { lineStyle: { color: "#374151" } },
+      axisLabel: { color: "#4B5563" },
+      splitLine: { lineStyle: { color: "#E5E7EB" } },
     },
     series: [
       {

--- a/app/components/AttentionAnalysisChart.tsx
+++ b/app/components/AttentionAnalysisChart.tsx
@@ -117,7 +117,7 @@ const AttentionAnalysisChart: FC<Props> = ({
       text: "Section-wise Average Attention",
       left: "center",
       top: 5,
-      textStyle: { color: "#E5E7EB", fontSize: 16, fontWeight: "600" },
+      textStyle: { color: "#374151", fontSize: 16, fontWeight: "600" },
     },
     tooltip: {
       trigger: "axis",
@@ -132,19 +132,19 @@ const AttentionAnalysisChart: FC<Props> = ({
     xAxis: {
       type: "category",
       data: summary.map((s) => sections.find(sec => sec.id === s.section)?.title || s.section),
-      axisLabel: { 
-        color: "#D1D5DB", 
+      axisLabel: {
+        color: "#4B5563",
         interval: 0, 
         alignText: "center",
         formatter: (value: string) => value.replace(/\s+/g, "\n"), // <-- satır sonu ekle
       },
-      axisLine: { lineStyle: { color: "#4B5563" } },
+      axisLine: { lineStyle: { color: "#9CA3AF" } },
     },
     yAxis: {
       type: "value",
       max: 100,
-      axisLabel: { color: "#9CA3AF", formatter: "{value}%" },
-      splitLine: { lineStyle: { color: "#374151" } },
+      axisLabel: { color: "#4B5563", formatter: "{value}%" },
+      splitLine: { lineStyle: { color: "#E5E7EB" } },
     },
     series: [
       {
@@ -195,7 +195,7 @@ const AttentionAnalysisChart: FC<Props> = ({
         text: `Attention Trend: ${sections.find((s) => s.id === selectedSec)?.title}`,
         left: "center",
         top: 5,
-        textStyle: { color: "#E5E7EB", fontSize: 16, fontWeight: "600" },
+        textStyle: { color: "#374151", fontSize: 16, fontWeight: "600" },
       },
       tooltip: { trigger: "axis" },
       grid: { top: "18%", bottom: "10%", left: "10%", right: "5%" },
@@ -204,14 +204,14 @@ const AttentionAnalysisChart: FC<Props> = ({
         name: "Time (seconds)",
         nameLocation: "middle",
         nameGap: 25,
-        axisLabel: { color: "#D1D5DB" },
-        axisLine: { lineStyle: { color: "#4B5563" } },
+        axisLabel: { color: "#4B5563" },
+        axisLine: { lineStyle: { color: "#9CA3AF" } },
       },
       yAxis: {
         type: "value",
         max: 100,
-        axisLabel: { color: "#9CA3AF", formatter: "{value}%" },
-        splitLine: { lineStyle: { color: "#374151" } },
+        axisLabel: { color: "#4B5563", formatter: "{value}%" },
+        splitLine: { lineStyle: { color: "#E5E7EB" } },
       },
       series: [
         {
@@ -264,7 +264,7 @@ const AttentionAnalysisChart: FC<Props> = ({
                 style={{ width: "100%", height }}
                 onEvents={{ click: onLineClick }}
               />
-              <div className="flex justify-center items-center gap-x-6 gap-y-2 flex-wrap mt-4 text-xs text-gray-400">
+              <div className="flex justify-center items-center gap-x-6 gap-y-2 flex-wrap mt-4 text-xs text-gray-600">
                 {incidentStats && (
                   <>
                     <span className="flex items-center gap-1.5">
@@ -284,7 +284,7 @@ const AttentionAnalysisChart: FC<Props> = ({
               </div>
             </div>
           ) : (
-            <div className="flex items-center justify-center h-full text-gray-500 rounded-lg bg-gray-800/30">
+            <div className="flex items-center justify-center h-full text-gray-500 rounded-lg bg-gray-100">
               <p className="text-center text-sm">
                 Select a section from the chart
                 <br />

--- a/app/components/ConferenceReactionsChart.tsx
+++ b/app/components/ConferenceReactionsChart.tsx
@@ -269,7 +269,7 @@ const ConferenceReactionsChart: React.FC<ConferenceReactionsChartProps> = ({
       textStyle: {
         fontSize: 18,
         fontWeight: 'bold',
-        color:'white'
+        color:'#374151'
       },
     },
     tooltip: {
@@ -288,7 +288,7 @@ const ConferenceReactionsChart: React.FC<ConferenceReactionsChartProps> = ({
       data: ['Laughter', 'Applause'],
       top: 50,
       itemGap: 30,
-      textStyle: { color: '#D1D5DB', fontSize: 12 },
+      textStyle: { color: '#4B5563', fontSize: 12 },
     },
     grid: {
       left: '10%',
@@ -303,6 +303,7 @@ const ConferenceReactionsChart: React.FC<ConferenceReactionsChartProps> = ({
       nameLocation: 'middle',
       nameGap: 30,
       axisLabel: {
+        color: '#4B5563',
         formatter: function(value: number) {
           const minutes = Math.floor(value / 60);
           const seconds = Math.floor(value % 60);
@@ -313,7 +314,7 @@ const ConferenceReactionsChart: React.FC<ConferenceReactionsChartProps> = ({
         show: true,
         lineStyle: {
           type: 'dashed',
-          color: '#e0e0e0'
+          color: '#E5E7EB'
         }
       }
     },
@@ -325,6 +326,7 @@ const ConferenceReactionsChart: React.FC<ConferenceReactionsChartProps> = ({
       min: 0,
       max: 1,
       axisLabel: {
+        color: '#4B5563',
         formatter: function(value: number) {
           return `${(value * 100).toFixed(0)}%`;
         }
@@ -333,7 +335,7 @@ const ConferenceReactionsChart: React.FC<ConferenceReactionsChartProps> = ({
         show: true,
         lineStyle: {
           type: 'dashed',
-          color: '#e0e0e0'
+          color: '#E5E7EB'
         }
       }
     },
@@ -391,7 +393,7 @@ const ConferenceReactionsChart: React.FC<ConferenceReactionsChartProps> = ({
         style={{ width, height }}
         opts={{ renderer: 'canvas' }}
       />
-      <div className="mt-4 text-sm text-white/50 text-center">
+      <div className="mt-4 text-sm text-gray-600 text-center">
         <p>Bubble size represents confidence level. Hover over points for detailed information.</p>
       </div>
     </div>

--- a/app/components/EmotionOverTimeChart.tsx
+++ b/app/components/EmotionOverTimeChart.tsx
@@ -89,10 +89,10 @@ const EmotionOverTimeChart: FC<EmotionOverTimeProps> = ({ data = demoEmotionOver
       show: true,
       position: 'insideEndTop',
       formatter: s.section,
-      color: '#E5E7EB',
+      color: '#374151',
       fontSize: 12,
       fontWeight: 'bold',
-      backgroundColor: '#374151',
+      backgroundColor: '#E5E7EB',
       padding: [4, 6],
       borderRadius: 4,
     },
@@ -104,25 +104,25 @@ const EmotionOverTimeChart: FC<EmotionOverTimeProps> = ({ data = demoEmotionOver
       text: 'Zamana Göre Genel Toplantı Duygu Akışı',
       left: 'center',
       top: 10,
-      textStyle: { color: '#F3F4F6', fontSize: 18, fontWeight: '600' },
+      textStyle: { color: '#374151', fontSize: 18, fontWeight: '600' },
     },
     tooltip: {
       trigger: 'axis',
-      backgroundColor: 'rgba(17, 24, 39, 0.9)',
-      borderColor: '#374151',
+      backgroundColor: 'rgba(255, 255, 255, 0.9)',
+      borderColor: '#E5E7EB',
       borderWidth: 1,
-      axisPointer: { type: 'cross', label: { backgroundColor: '#6B7280' } },
+      axisPointer: { type: 'cross', label: { backgroundColor: '#9CA3AF' } },
       formatter: (params: any[]) => {
         if (!params || !params.length) return '';
         const minute = params[0].axisValue;
-        let html = `<div style='font-weight:600;margin-bottom:8px;color:#F3F4F6;'>Zaman: ${minute} dakika</div>`;
-        html += '<div style="margin-bottom:4px;color:#D1D5DB;font-size:13px;font-weight:500;">Duygular:</div>';
+        let html = `<div style='font-weight:600;margin-bottom:8px;color:#374151;'>Zaman: ${minute} dakika</div>`;
+        html += '<div style="margin-bottom:4px;color:#4B5563;font-size:13px;font-weight:500;">Duygular:</div>';
         params
           .filter((p) => p.value > 0)
           .sort((a, b) => b.value - a.value)
           .forEach((p) => {
             const percentage = (p.value * 100).toFixed(1);
-            html += `<div style='margin:2px 0;'><span style='display:inline-block;width:12px;height:12px;border-radius:2px;background:${COLORS[p.seriesName]};margin-right:8px;'></span><span style='color:#F3F4F6;'>${p.seriesName}:</span> <b style='color:#34D399;'>${percentage}%</b></div>`;
+            html += `<div style='margin:2px 0;'><span style='display:inline-block;width:12px;height:12px;border-radius:2px;background:${COLORS[p.seriesName]};margin-right:8px;'></span><span style='color:#374151;'>${p.seriesName}:</span> <b style='color:#34D399;'>${percentage}%</b></div>`;
           });
         return html;
       },
@@ -130,7 +130,7 @@ const EmotionOverTimeChart: FC<EmotionOverTimeProps> = ({ data = demoEmotionOver
     legend: {
       data: activeEmotions,
       top: 45,
-      textStyle: { color: '#D1D5DB', fontSize: 12 },
+      textStyle: { color: '#4B5563', fontSize: 12 },
       itemWidth: 14,
       itemHeight: 14,
       icon: 'roundRect',
@@ -144,9 +144,9 @@ const EmotionOverTimeChart: FC<EmotionOverTimeProps> = ({ data = demoEmotionOver
       name: 'Zaman (dakika)',
       nameLocation: 'middle',
       nameGap: 25,
-      nameTextStyle: { color: '#9CA3AF', fontSize: 12 },
-      axisLabel: { color: '#9CA3AF', fontSize: 11 },
-      axisLine: { lineStyle: { color: '#4B5563' } },
+      nameTextStyle: { color: '#4B5563', fontSize: 12 },
+      axisLabel: { color: '#4B5563', fontSize: 11 },
+      axisLine: { lineStyle: { color: '#9CA3AF' } },
       splitLine: { show: false },
     },
     yAxis: {
@@ -156,13 +156,13 @@ const EmotionOverTimeChart: FC<EmotionOverTimeProps> = ({ data = demoEmotionOver
       name: 'Duygu Şiddeti',
       nameLocation: 'middle',
       nameGap: 40,
-      nameTextStyle: { color: '#9CA3AF', fontSize: 12 },
+      nameTextStyle: { color: '#4B5563', fontSize: 12 },
       axisLabel: {
-        color: '#9CA3AF',
+        color: '#4B5563',
         fontSize: 11,
         formatter: (value: number) => `${(value * 100).toFixed(0)}%`,
       },
-      splitLine: { lineStyle: { color: '#374151', type: 'solid', opacity: 0.3 } },
+      splitLine: { lineStyle: { color: '#E5E7EB', type: 'solid', opacity: 0.3 } },
     },
     series,
   };
@@ -181,21 +181,21 @@ const EmotionOverTimeChart: FC<EmotionOverTimeProps> = ({ data = demoEmotionOver
         />
       </div>
       <div className='w-72 m-auto p-4 flex flex-col'>
-        <h3 className='text-base font-semibold text-gray-200 mb-3 border-b border-gray-600 pb-2'>
+        <h3 className='text-base font-semibold text-gray-700 mb-3 border-b border-gray-300 pb-2'>
           Toplantı Bölümleri
         </h3>
         <div className='space-y-3 overflow-y-auto'>
           {data.sections.map((section, index) => (
-            <div key={index} className='bg-gray-800/50 rounded-lg p-3'>
+            <div key={index} className='bg-gray-50 rounded-lg p-3'>
               <div className='flex items-center justify-between mb-1'>
-                <h4 className='font-medium text-gray-200 text-sm'>
+                <h4 className='font-medium text-gray-700 text-sm'>
                   {section.section}
                 </h4>
-                <span className='text-xs text-gray-400 bg-gray-700/50 px-2 py-0.5 rounded'>
+                <span className='text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded'>
                   {section.start}-{section.end} dk
                 </span>
               </div>
-              <p className='text-gray-400 text-xs leading-relaxed'>
+              <p className='text-gray-600 text-xs leading-relaxed'>
                 {section.topic}
               </p>
             </div>

--- a/app/components/OverallEmotionDonutChart.tsx
+++ b/app/components/OverallEmotionDonutChart.tsx
@@ -52,7 +52,7 @@ const OverallEmotionDonutChart: FC<Props> = ({ data = defaultOverallEmotionDistr
       text: "Overall Emotion Distribution in Meeting",
       left: "center",
       top: 10,
-      textStyle: { color: "#E5E7EB", fontSize: 16 },
+      textStyle: { color: "#374151", fontSize: 16 },
     },
     tooltip: {
       trigger: "item",
@@ -63,7 +63,7 @@ const OverallEmotionDonutChart: FC<Props> = ({ data = defaultOverallEmotionDistr
       left: "center",
       itemWidth: 14,
       itemHeight: 14,
-      textStyle: { color: "#F3F4F6", fontSize: 12 },
+      textStyle: { color: "#4B5563", fontSize: 12 },
       data: data.map((d) => d.emotion),
     },
     series: [
@@ -82,7 +82,7 @@ const OverallEmotionDonutChart: FC<Props> = ({ data = defaultOverallEmotionDistr
             fontSize: 14,
             fontWeight: "bold",
             formatter: "{b}\n{d}%",
-            color: "#F3F4F6",
+            color: "#374151",
           },
         },
         labelLine: {

--- a/app/components/VIPEmotionRadarChart.tsx
+++ b/app/components/VIPEmotionRadarChart.tsx
@@ -88,17 +88,17 @@ const VIPEmotionRadarChart: FC<Props> = ({ data = vipEmotionProfiles, height = 3
       text: "VIP Emotion Profile",
       left: "center",
       top: 5,
-      textStyle: { color: "#E5E7EB", fontSize: 16, fontWeight: "600" },
+      textStyle: { color: "#374151", fontSize: 16, fontWeight: "600" },
     },
     tooltip: {
       trigger: "item",
-      className: "rounded-lg bg-gray-800/90 border-gray-700 text-gray-200",
+      className: "rounded-lg bg-white border-gray-200 text-gray-700",
       borderWidth: 1,
     },
     legend: {
       data: selected,
       top: 40,
-      textStyle: { color: "#D1D5DB" },
+      textStyle: { color: "#4B5563" },
       itemWidth: 12,
       itemHeight: 12,
       icon: "circle",
@@ -107,7 +107,7 @@ const VIPEmotionRadarChart: FC<Props> = ({ data = vipEmotionProfiles, height = 3
       indicator: indicators,
       center: ["50%", "60%"],
       radius: "65%",
-      axisName: { color: "#D1D5DB", fontSize: 11, padding: 4 },
+      axisName: { color: "#4B5563", fontSize: 11, padding: 4 },
       splitLine: { lineStyle: { color: "rgba(107, 114, 128, 0.3)" } },
       splitArea: {
         areaStyle: {
@@ -134,7 +134,7 @@ const VIPEmotionRadarChart: FC<Props> = ({ data = vipEmotionProfiles, height = 3
   return (
     <div className="rounded-xl p-4 h-full flex flex-col">
       <div className="flex flex-col sm:flex-row sm:items-center gap-3 mb-4">
-        <span className="text-gray-200 text-sm font-medium shrink-0">Select VIP(s) (Max 3):</span>
+        <span className="text-gray-700 text-sm font-medium shrink-0">Select VIP(s) (Max 3):</span>
         <div className="flex flex-wrap gap-2">
           {names.map((name) => (
             <button
@@ -144,7 +144,7 @@ const VIPEmotionRadarChart: FC<Props> = ({ data = vipEmotionProfiles, height = 3
               className={`px-3 py-1 text-xs rounded-full transition-all duration-200 ease-in-out border ${
                 selected.includes(name)
                   ? "bg-blue-600 text-white font-semibold border-blue-500 shadow-md"
-                  : "bg-gray-700/50 text-gray-300 hover:bg-gray-600/70 border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200 border-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
               }`}
             >
               {name}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,46 +19,46 @@ const App = () => {
   if (!isClient) return null;
 
   return (
-    <div className="bg-[#0a0a0a] text-[#ededed] min-h-screen p-4 sm:p-8 font-sans">
+    <div className="bg-background text-foreground min-h-screen p-4 sm:p-8 font-sans">
       {/* Header */}
       <header className="text-center mb-10">
         <h1 className="text-4xl font-bold tracking-tight">Conference Camera Analysis Dashboard</h1>
-        <p className="text-lg text-gray-400 mt-2">Visualized Conference Metrics</p>
+        <p className="text-lg text-gray-600 mt-2">Visualized Conference Metrics</p>
       </header>
 
       {/* Main Grid */}
       <main className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* 1. Satır: Shouting Chart (tam genişlik) */}
-        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+        <div className="lg:col-span-2 bg-white p-6 rounded-xl shadow-lg border border-gray-200">
           <AttendanceTrendChart />
         </div>
 
         {/* 2. Satır: Participant Activity Timeline (tam genişlik) */}
-        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+        <div className="lg:col-span-2 bg-white p-6 rounded-xl shadow-lg border border-gray-200">
           <AttentionAnalysisChart />
         </div>
 
         {/* 3. Satır: Emotion Timeline Area Chart (tam genişlik) */}
-        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+        <div className="lg:col-span-2 bg-white p-6 rounded-xl shadow-lg border border-gray-200">
           <EmotionOverTimeChart />
         </div>
 
         {/* 4. Satır: Radar + Topic Bar */}
-        <div className="bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+        <div className="bg-white p-6 rounded-xl shadow-lg border border-gray-200">
           <OverallEmotionDonutChart />
         </div>
-        <div className="bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+        <div className="bg-white p-6 rounded-xl shadow-lg border border-gray-200">
           <VIPEmotionRadarChart />
         </div>
 
                 {/* 5. Satır: Reactions Chart (tam genişlik) */}
-        <div className="lg:col-span-2 bg-[#171717] p-6 rounded-xl shadow-lg border border-gray-700">
+        <div className="lg:col-span-2 bg-white p-6 rounded-xl shadow-lg border border-gray-200">
           <ConferenceReactionsChart />
         </div>
       </main>
 
       {/* Footer */}
-      <footer className="text-center mt-12 text-gray-500">
+      <footer className="text-center mt-12 text-gray-600">
         <p>&copy; {new Date().getFullYear()} Conference Camera Analysis. Tüm hakları saklıdır.</p>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- adjust AttendanceTrendChart colors for light theme
- update AttentionAnalysisChart styling for light mode
- adapt EmotionOverTimeChart, OverallEmotionDonutChart, VIPEmotionRadarChart
- tweak ConferenceReactionsChart and main page layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c721157e48324a6f8386e78dec640