### PR TITLE
Improve dashboard layout for mobile

### DIFF
--- a/app/dashboard/components/shared/Sidebar.tsx
+++ b/app/dashboard/components/shared/Sidebar.tsx
@@ -39,7 +39,7 @@ export default function Sidebar() {
   };
 
   return (
-    <div className="w-[28rem] h-screen bg-gray-50 shadow-md flex flex-col p-6">
+    <div className="w-full md:w-[28rem] h-auto md:h-screen bg-gray-50 shadow-md flex flex-col p-6 mb-4 md:mb-0">
       <div className="flex-1 overflow-y-auto">
         <h2 className="text-xl font-bold text-gray-900">Conferences</h2>
         <ul className="mt-4 space-y-2">

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -6,7 +6,7 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex h-screen bg-gray-100">
+    <div className="flex h-screen bg-gray-100 flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-6 overflow-y-auto">{children}</main>
     </div>


### PR DESCRIPTION
## Summary
- make the dashboard layout vertical on small screens
- adjust Sidebar width and height responsively

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c9186829c8324a583ee741082f180