### PR TITLE
Fix legend color mismatch in emotion area chart

### DIFF
--- a/app/dashboard/components/EmotionOverTimeChart.tsx
+++ b/app/dashboard/components/EmotionOverTimeChart.tsx
@@ -85,6 +85,8 @@ const EmotionOverTimeChart: FC<EmotionOverTimeProps> = ({ data = demoEmotionOver
       stack: 'emotions',
       smooth: true,
       symbol: 'none',
+      color: COLORS[emotion],
+      itemStyle: { color: COLORS[emotion] },
       areaStyle: { color: COLORS[emotion], opacity: 0.8 },
       lineStyle: { width: 1, color: COLORS[emotion] },
       emphasis: { focus: 'series', areaStyle: { opacity: 1 } },


### PR DESCRIPTION
## Summary
- ensure legend color matches area color for each emotion

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c9978e4908324b5e0661925eee18b